### PR TITLE
Settings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -544,7 +544,7 @@ VendorSettingsCommand = {
 
 <xmp class="cddl local-cddl">
 VendorSettingsResult = {
-  VendorSettingsSetSettingsResult
+  VendorSettingsGetSettingsResult
 }
 </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -554,8 +554,10 @@ VendorSettingsResult = {
 
 [=Local end definition=]:
 
-<xmp class="cddl local-ccdl">
-VendorSettingsGetSettingsResult = [1* VendorSettingsGetSettingsResultItem ]
+<xmp class="cddl local-cddl">
+VendorSettingsGetSettingsResult = {
+  settings: [1* VendorSettingsGetSettingsResultItem ],
+}
 
 VendorSettingsGetSettingsResultItem = {
   name: text,
@@ -564,7 +566,7 @@ VendorSettingsGetSettingsResultItem = {
 }
 </xmp>
 
-The `VendorSettingsGetSettingsResult` type is a list of settings and their values.
+The `VendorSettingsGetSettingsResult` type contains a list of settings and their values.
 
 ### Commands ### {#module-settings-commands}
 
@@ -581,7 +583,9 @@ This command sets the values of one or more settings.
       params: VendorSettingsSetSettingsParameters
     }
 
-    VendorSettingSetSettingsParameters = [1* VendorSettingSetSettingsParametersItem ]
+    VendorSettingSetSettingsParameters = {
+      settings: [1* VendorSettingSetSettingsParametersItem ],
+    }
 
     VendorSettingSetSettingsParametersItem = {
       name: text,
@@ -613,7 +617,9 @@ This command returns a list of the requested settings and their values.
       params: VendorSettingsGetSettingsParameters
     }
 
-    VendorSettingsGetSettingsParameters = [1* VendorSettingsGetSettingsParametersItem ]
+    VendorSettingsGetSettingsParameters = {
+      settings: [1* VendorSettingsGetSettingsParametersItem ],
+    }
 
     VendorSettingsGetSettingsParametersItem = {
       name: text,

--- a/index.bs
+++ b/index.bs
@@ -1,4 +1,4 @@
-<pre class='metadata'>
+<xmp class='metadata'>
 Title: ARIA-AT Automation
 Shortname: aria-at-automation
 Level: 1
@@ -10,7 +10,19 @@ Editor: Simon Pieters, Bocoup https://bocoup.com, simon@bocoup.com
 !Tests: <a href=https://github.com/w3c/web-platform-tests/tree/master/aria-at-automation>web-platform-tests aria-at-automation/</a> (<a href=https://github.com/w3c/web-platform-tests/labels/aria-at-automation>ongoing work</a>)
 Abstract: A short description of your spec, one or two sentences. (TODO)
 Markup Shorthands: markdown yes
-</pre>
+</xmp>
+
+<xmp class='link-defaults'>
+spec:infra; type:dfn; for:/; text:set
+</xmp>
+
+<style>
+table { border-collapse: collapse; border-style: hidden hidden none hidden; }
+table thead, table tbody { border-bottom: solid; }
+table tbody th { text-align: left; }
+table tbody th:first-child { border-left: solid; }
+table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
+</style>
 
 <pre class='link-defaults'>
 spec:infra; type:dfn; for:/; text:set
@@ -106,7 +118,7 @@ This section gives the initial contents of the remote end definition and local e
 
 [=Remote end definition=]
 
-<pre class="cddl remote-cddl">
+<xmp class="cddl remote-cddl">
 Command = {
   id: uint,
   CommandData,
@@ -114,15 +126,16 @@ Command = {
 }
 
 CommandData = (
-  SessionCommand
+  SessionCommand //
+  VendorSettingsCommand
 )
 
 EmptyParams = { *text => any }
-</pre>
+</xmp>
 
 [=Local end definition=]:
 
-<pre class="cddl local-cddl">
+<xmp class="cddl local-cddl">
 Message = (
   CommandResponse //
   ErrorResponse //
@@ -145,7 +158,8 @@ ErrorResponse = {
 
 ResultData = (
   EmptyResult //
-  SessionResult
+  SessionResult //
+  VendorSettingsResult
 )
 
 EmptyResult = {}
@@ -158,7 +172,7 @@ Event = {
 EventData = (
   InteractionEvent
 )
-</pre>
+</xmp>
 
 Capabilities {#protocol-capabilities}
 -------------------------------------
@@ -424,15 +438,15 @@ The session Module {#module-session}
 
 [=Remote end definition=]:
 
-<pre class="cddl remote-cddl">
+<xmp class="cddl remote-cddl">
 SessionCommand = (SessionNewCommand)
-</pre>
+</xmp>
 
 [=Local end definition=]
 
-<pre class="cddl local-cddl">
+<xmp class="cddl local-cddl">
 SessionResult = (SessionNewResult)
-</pre>
+</xmp>
 
 ### Types ### {#module-session-types}
 
@@ -440,14 +454,14 @@ SessionResult = (SessionNewResult)
 
 [=Remote end definition=] and [=local end definition=]:
 
-<pre class="cddl remote-cddl local-cddl">
+<xmp class="cddl remote-cddl local-cddl">
 CapabilitiesRequest = {
   ?atName: text,
   ?atVersion: text,
   ?platformName: text,
   *text => any
 }
-</pre>
+</xmp>
 
 The `CapabilitiesRequest` type represents capabilities requested for a session.
 
@@ -461,7 +475,7 @@ The <dfn>session.new</dfn> command allows creating a new [=session=]. This is a 
   <dt>Command Type
   <dd>
 
-  <pre class="cddl remote-cddl">
+  <xmp class="cddl remote-cddl">
   SessionNewCommand = {
     method: "session.new",
     params: {capabilities: CapabilitiesRequestParameters},
@@ -470,14 +484,14 @@ The <dfn>session.new</dfn> command allows creating a new [=session=]. This is a 
   CapabilitiesRequestParameters = {
     ?alwaysMatch: CapabilitiesRequest,
   }
-  </pre>
+  </xmp>
 
   Note: `firstMatch` is not included currently to reduce complexity.
 
   <dt>Return Type
   <dd>
 
-  <pre class="cddl local-cddl">
+  <xmp class="cddl local-cddl">
   SessionNewResult = {
     sessionId: text,
     capabilities: {
@@ -487,7 +501,7 @@ The <dfn>session.new</dfn> command allows creating a new [=session=]. This is a 
       *text => any
     }
   }
-  </pre>
+  </xmp>
 
 </dl>
 
@@ -505,60 +519,145 @@ The [=remote end steps=] given |session| and |command parameters| are:
 10. Let |body| be a new [=map=] matching the `SessionNewResult` production, with the `sessionId` field set to |session|'s [=session ID=], and the `capabilities` field set to |capabilities|.
 11. Return [=success=] with data |body|.
 
-The settings Module {#module-settings}
+The &lt;vendor>:settings Module {#module-vendor-settings}
 --------------------------------------
 
-Issue: TODO any setting, excluding security-sensitive settings, for each AT.
+Currently, there are no standardized settings. Implementations that wish to allow controlling and reading settings through the protocol defined in this specification must support settings as an <a>extension module</a>, with the structure defined in this section. Implementations are strongly encouraged to review the security implications of each setting, and only support the settings that are deemed safe. It is not defined what constitutes a setting, however, it is intended to represent user preferences such as the default voice, or the default rate of speech.
 
-The Interaction Module {#module-interaction}
---------------------------------------------
+In the schema definitions in this section, `<vendor>` is a placeholder for an <a>implementation-defined</a> prefix for the <a>extension module</a>. The value of the prefix should be the name of the vendor or the assistive technology product, as appropriate.
 
-### Definition ### {#module-interaction-definition}
+Note: The prefix could be, for example, `nvda`, `jaws`, or `macOSVoiceOver`.
+
+### Definition ### {#module-vendor-settings-definition}
+
+<a>Remote end definition</a>
+
+<xmp class="cddl remote-cddl">
+VendorSettingsCommand = {
+  VendorSettingsSetSettingsCommand //
+  VendorSettingsGetSettingsCommand //
+  VendorSettingsGetSupportedSettingsCommand
+}
+</xmp>
+
+<a>Local end definition</a>
+
+<xmp class="cddl local-cddl">
+VendorSettingsResult = {
+  VendorSettingsSetSettingsResult
+}
+</xmp>
+
+### Types ### {#module-vendor-settings-types}
+
+#### The VendorSettingsGetSettingsResult type #### {#module-vendor-settings-get-settings-result}
 
 [=Local end definition=]:
 
-<pre class="cddl local-cddl">
+<xmp class="cddl local-ccdl">
+VendorSettingsGetSettingsResult = [1* VendorSettingsGetSettingsResultItem ]
 
-InteractionEvent = (InteractionCapturedOutputEvent)
-
-</pre>
-
-### Types ### {#module-interaction-types}
-
-<pre class="cddl local-cddl">
-InteractionCapturedOutputParameters = {
-  data: text,
+VendorSettingsGetSettingsResultItem = {
+  name: text,
+  value: any,
   *text => any
 }
-</pre>
+</xmp>
 
-### Commands ### {#module-interaction-commands}
+The `VendorSettingsGetSettingsResult` type is a list of settings and their values.
 
-None.
+### Commands ### {#module-settings-commands}
 
-### Events ### {#module-interaction-events}
+#### The &lt;vendor>:settings.setSettings Command #### {#command-vendor-settings-set-settings}
+
+This command sets the values of one or more settings.
 
 <dl>
-  <dt>Event Type
+  <dt>Command Type</dt>
   <dd>
+    <xmp class="cddl remote-cddl">
+    VendorSettingsSetSettingsCommand = {
+      method: "<vendor>:settings.setSettings",
+      params: VendorSettingsSetSettingsParameters
+    }
 
-  <pre class="cddl local-cddl">
-  InteractionCapturedOutputEvent = {
-    method: "interaction.capturedOutput",
-    params: InteractionCapuredOutputParameters
-  }
-  </pre>
+    VendorSettingSetSettingsParameters = [1* VendorSettingSetSettingsParametersItem ]
 
+    VendorSettingSetSettingsParametersItem = {
+      name: text,
+      value: any,
+      *text => any
+    }
+    </xmp>
+  </dd>
+  <dt>Return Type</dt>
+  <dd>
+    <xmp class="cddl">
+    EmptyResult
+    </xmp>
+  </dd>
 </dl>
 
-The [=remote end event trigger=] is:
+The <a>remote end steps</a> given |session| and |command parameters| are <a>implementation-defined</a>.
 
-When the assistive technology would send some text |data| (a string, without speech-specific markup or annotations) to the Text-To-Speech system, or equivalent for non-speech assistive technology software, run these steps:
+#### The &lt;vendor>settings.getSettings Command #### {#command-vendor-settings-get-settings}
 
-1. Optionally, return. This step allows for an [=implementation-defined=] security check, to sandbox what information to expose.
-2. Let |params| be a [=map=] matching the `InteractionCapturedOutputParameters` production with the `data` field set to |data|.
-3. Let |body| be a [=map=] matching the `InteractionCapturedOutputEvent` production with the `params` field set to |params|.
-4. [=Emit an event=] with |session| and |body|.
+This command returns a list of the requested settings and their values.
+
+<dl>
+  <dt>Command Type</dt>
+  <dd>
+    <xmp class="cddl remote-cddl">
+    VendorSettingsGetSettingsCommand = {
+      method: "<vendor>:settings.getSettings",
+      params: VendorSettingsGetSettingsParameters
+    }
+
+    VendorSettingsGetSettingsParameters = [1* VendorSettingsGetSettingsParametersItem ]
+
+    VendorSettingsGetSettingsParametersItem = {
+      name: text,
+      *text => any
+    }
+    </xmp>
+  </dd>
+  <dt>Return Type</dt>
+  <dd>
+    <xmp class="cddl">
+    VendorSettingsGetSettingsResult
+    </xmp>
+  </dd>
+</dl>
+
+The <a>remote end steps</a> given |session| and |command parameters| are <a>implementation-defined</a>.
+
+#### The &lt;vendor>settings.getSupportedSettings Command #### {#command-vendor-settings-get-supported-settings}
+
+This command returns a list of all settings that the [=remote end=] supports, and their values.
+
+<dl>
+  <dt>Command Type</dt>
+  <dd>
+    <xmp class="cddl remote-cddl">
+    VendorSettingsGetSupportedSettingsCommand = {
+      method: "<vendor>:settings.getSupportedSettings",
+      params: EmptyParams
+    }
+    </xmp>
+  </dd>
+  <dt>Return Type</dt>
+  <dd>
+    <xmp class="cddl">
+    VendorSettingsGetSettingsResult
+    </xmp>
+  </dd>
+</dl>
+
+The <a>remote end steps</a> given |session| and |command parameters| are <a>implementation-defined</a>.
+
+#### Events #### {#module-vendor-settings-events}
+
+Issue: Do we need a "setting changed" event?
 
 Privacy {#privacy}
 ==================

--- a/schemas/at-driver-local.cddl
+++ b/schemas/at-driver-local.cddl
@@ -20,7 +20,8 @@ ErrorResponse = {
 
 ResultData = (
   EmptyResult //
-  SessionResult
+  SessionResult //
+  VendorSettingsResult
 )
 
 EmptyResult = {}
@@ -53,14 +54,6 @@ SessionNewResult = {
   }
 }
 
-InteractionEvent = (InteractionCapturedOutputEvent)
-
-InteractionCapturedOutputParameters = {
-  data: text,
-  *text => any
-}
-
-InteractionCapturedOutputEvent = {
-  method: "interaction.capturedOutput",
-  params: InteractionCapuredOutputParameters
+VendorSettingsResult = {
+  VendorSettingsSetSettingsResult
 }

--- a/schemas/at-driver-local.cddl
+++ b/schemas/at-driver-local.cddl
@@ -55,5 +55,5 @@ SessionNewResult = {
 }
 
 VendorSettingsResult = {
-  VendorSettingsSetSettingsResult
+  VendorSettingsGetSettingsResult
 }

--- a/schemas/at-driver-local.cddl
+++ b/schemas/at-driver-local.cddl
@@ -57,3 +57,13 @@ SessionNewResult = {
 VendorSettingsResult = {
   VendorSettingsGetSettingsResult
 }
+
+VendorSettingsGetSettingsResult = {
+  settings: [1* VendorSettingsGetSettingsResultItem ],
+}
+
+VendorSettingsGetSettingsResultItem = {
+  name: text,
+  value: any,
+  *text => any
+}

--- a/schemas/at-driver-remote.cddl
+++ b/schemas/at-driver-remote.cddl
@@ -40,7 +40,9 @@ VendorSettingsSetSettingsCommand = {
   params: VendorSettingsSetSettingsParameters
 }
 
-VendorSettingSetSettingsParameters = [1* VendorSettingSetSettingsParametersItem ]
+VendorSettingSetSettingsParameters = {
+  settings: [1* VendorSettingSetSettingsParametersItem ],
+}
 
 VendorSettingSetSettingsParametersItem = {
   name: text,
@@ -53,7 +55,9 @@ VendorSettingsGetSettingsCommand = {
   params: VendorSettingsGetSettingsParameters
 }
 
-VendorSettingsGetSettingsParameters = [1* VendorSettingsGetSettingsParametersItem ]
+VendorSettingsGetSettingsParameters = {
+  settings: [1* VendorSettingsGetSettingsParametersItem ],
+}
 
 VendorSettingsGetSettingsParametersItem = {
   name: text,

--- a/schemas/at-driver-remote.cddl
+++ b/schemas/at-driver-remote.cddl
@@ -5,7 +5,8 @@ Command = {
 }
 
 CommandData = (
-  SessionCommand
+  SessionCommand //
+  VendorSettingsCommand
 )
 
 EmptyParams = { *text => any }
@@ -26,4 +27,40 @@ SessionNewCommand = {
 
 CapabilitiesRequestParameters = {
   ?alwaysMatch: CapabilitiesRequest,
+}
+
+VendorSettingsCommand = {
+  VendorSettingsSetSettingsCommand //
+  VendorSettingsGetSettingsCommand //
+  VendorSettingsGetSupportedSettingsCommand
+}
+
+VendorSettingsSetSettingsCommand = {
+  method: "<vendor>:settings.setSettings",
+  params: VendorSettingsSetSettingsParameters
+}
+
+VendorSettingSetSettingsParameters = [1* VendorSettingSetSettingsParametersItem ]
+
+VendorSettingSetSettingsParametersItem = {
+  name: text,
+  value: any,
+  *text => any
+}
+
+VendorSettingsGetSettingsCommand = {
+  method: "<vendor>:settings.getSettings",
+  params: VendorSettingsGetSettingsParameters
+}
+
+VendorSettingsGetSettingsParameters = [1* VendorSettingsGetSettingsParametersItem ]
+
+VendorSettingsGetSettingsParametersItem = {
+  name: text,
+  *text => any
+}
+
+VendorSettingsGetSupportedSettingsCommand = {
+  method: "<vendor>:settings.getSupportedSettings",
+  params: EmptyParams
 }

--- a/scripts/extract-schemas.js
+++ b/scripts/extract-schemas.js
@@ -19,7 +19,7 @@ const formatCddl = cddl => cddl.join('\n\n').trim() + '\n';
 
 const extractCddlFromSpec = async () => {
   const source = await fs.readFile('index.bs', { encoding: 'utf8' });
-  const matches = [...source.matchAll(/^([ \t]*)<pre class=['"]cddl((?: [a-zA-Z0-9_-]+)+)['"]>([\s\S]*?)<\/pre>/gm)];
+  const matches = [...source.matchAll(/^([ \t]*)<(?:pre|xmp) class=['"]cddl((?: [a-zA-Z0-9_-]+)+)['"]>([\s\S]*?)<\/(?:pre|xmp)>/gm)];
 
   const [local, remote] = matches.reduce(([local, remote], match) => {
     const [_, indentation, cssClass, content] = match;


### PR DESCRIPTION
This change covers milestone 1 in https://github.com/w3c/aria-at-automation/issues/15 . The approach here reflects what we discussed in our previous meeting, see https://lists.w3.org/Archives/Public/www-archive/2022Jun/att-0004/05-23-aria-at-minutes.html#t02

Currently, these suggested vendor-specific commands defined:

- set one or more settings
- get one or more settings
- get supported settings

@mcking65 also suggested in the meeting: reset to defaults, and load config file. I'm not sure we need these, at least initially.

However, I've left an inline issue about a possible event, which the remote end could send if a setting is changed by the user or by some other software.

(I've edited this description to reflect the current state.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/pull/22.html" title="Last updated on Sep 29, 2022, 6:45 PM UTC (f48b7c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/22/9edc5c4...f48b7c0.html" title="Last updated on Sep 29, 2022, 6:45 PM UTC (f48b7c0)">Diff</a>