### PR TITLE
Add back 'capture output' section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -665,6 +665,56 @@ The <a>remote end steps</a> given |session| and |command parameters| are <a>impl
 
 Issue: Do we need a "setting changed" event?
 
+The Interaction Module {#module-interaction}
+--------------------------------------------
+
+### Definition ### {#module-interaction-definition}
+
+[=Local end definition=]:
+
+<xmp class="cddl local-cddl">
+
+InteractionEvent = (InteractionCapturedOutputEvent)
+
+</xmp>
+
+### Types ### {#module-interaction-types}
+
+<xmp class="cddl local-cddl">
+InteractionCapturedOutputParameters = {
+  data: text,
+  *text => any
+}
+</xmp>
+
+### Commands ### {#module-interaction-commands}
+
+None.
+
+### Events ### {#module-interaction-events}
+
+<dl>
+  <dt>Event Type
+  <dd>
+
+  <xmp class="cddl local-cddl">
+  InteractionCapturedOutputEvent = {
+    method: "interaction.capturedOutput",
+    params: InteractionCapuredOutputParameters
+  }
+  </xmp>
+
+</dl>
+
+The [=remote end event trigger=] is:
+
+When the assistive technology would send some text |data| (a string, without speech-specific markup or annotations) to the Text-To-Speech system, or equivalent for non-speech assistive technology software, run these steps:
+
+1. Optionally, return. This step allows for an [=implementation-defined=] security check, to sandbox what information to expose.
+2. Let |params| be a [=map=] matching the `InteractionCapturedOutputParameters` production with the `data` field set to |data|.
+3. Let |body| be a [=map=] matching the `InteractionCapturedOutputEvent` production with the `params` field set to |params|.
+4. [=Emit an event=] with |session| and |body|.
+
 Privacy {#privacy}
 ==================
 

--- a/schemas/at-driver-local.cddl
+++ b/schemas/at-driver-local.cddl
@@ -67,3 +67,15 @@ VendorSettingsGetSettingsResultItem = {
   value: any,
   *text => any
 }
+
+InteractionEvent = (InteractionCapturedOutputEvent)
+
+InteractionCapturedOutputParameters = {
+  data: text,
+  *text => any
+}
+
+InteractionCapturedOutputEvent = {
+  method: "interaction.capturedOutput",
+  params: InteractionCapuredOutputParameters
+}


### PR DESCRIPTION
This text was added in #25 and was accidentally removed when merging #22.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/pull/31.html" title="Last updated on Oct 19, 2022, 1:36 PM UTC (9b7952e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/31/818d942...9b7952e.html" title="Last updated on Oct 19, 2022, 1:36 PM UTC (9b7952e)">Diff</a>