### PR TITLE
Editorial: Correct references to "result type"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -488,7 +488,7 @@ The <dfn>session.new</dfn> command allows creating a new [=session=]. This is a 
 
   Note: `firstMatch` is not included currently to reduce complexity.
 
-  <dt>Result Type
+  <dt>[=Result Type=]
   <dd>
 
   <xmp class="cddl local-cddl">
@@ -594,7 +594,7 @@ This command sets the values of one or more settings.
     }
     </xmp>
   </dd>
-  <dt>Result Type</dt>
+  <dt>[=Result Type=]</dt>
   <dd>
     <xmp class="cddl">
     EmptyResult
@@ -627,7 +627,7 @@ This command returns a list of the requested settings and their values.
     }
     </xmp>
   </dd>
-  <dt>Result Type</dt>
+  <dt>[=Result Type=]</dt>
   <dd>
     <xmp class="cddl">
     VendorSettingsGetSettingsResult
@@ -651,7 +651,7 @@ This command returns a list of all settings that the [=remote end=] supports, an
     }
     </xmp>
   </dd>
-  <dt>Result Type</dt>
+  <dt>[=Result Type=]</dt>
   <dd>
     <xmp class="cddl">
     VendorSettingsGetSettingsResult

--- a/index.bs
+++ b/index.bs
@@ -274,7 +274,7 @@ Each [=command=] is defined by:
     * `method` which is a string literal in the form `[module name].[method name]`. This is the <dfn>command name</dfn>.
     * `params` which defines a mapping containing data that to be passed into the command. The populated value of this map is the <dfn>command parameters</dfn>.
 * A <dfn>result type</dfn>, which is defined by the [=local end definition=] fragment.
-* A set of <dfn>remote end steps</dfn> which define the actions to take for a command given a [=session=] and [=command parameters=] and return an instance of the command [=return type=].
+* A set of <dfn>remote end steps</dfn> which define the actions to take for a command given a [=session=] and [=command parameters=] and return an instance of the command [=result type=].
 
 A command that can run without an active session is a <dfn>static command</dfn>. Commands are not static commands unless stated in their definition.
 
@@ -488,7 +488,7 @@ The <dfn>session.new</dfn> command allows creating a new [=session=]. This is a 
 
   Note: `firstMatch` is not included currently to reduce complexity.
 
-  <dt>Return Type
+  <dt>Result Type
   <dd>
 
   <xmp class="cddl local-cddl">
@@ -594,7 +594,7 @@ This command sets the values of one or more settings.
     }
     </xmp>
   </dd>
-  <dt>Return Type</dt>
+  <dt>Result Type</dt>
   <dd>
     <xmp class="cddl">
     EmptyResult
@@ -627,7 +627,7 @@ This command returns a list of the requested settings and their values.
     }
     </xmp>
   </dd>
-  <dt>Return Type</dt>
+  <dt>Result Type</dt>
   <dd>
     <xmp class="cddl">
     VendorSettingsGetSettingsResult
@@ -651,7 +651,7 @@ This command returns a list of all settings that the [=remote end=] supports, an
     }
     </xmp>
   </dd>
-  <dt>Return Type</dt>
+  <dt>Result Type</dt>
   <dd>
     <xmp class="cddl">
     VendorSettingsGetSettingsResult


### PR DESCRIPTION
"Commands" are generally described to include a "result type," but none of the commands defined actually include such a value. They do include a "return type," as defined by WEBIDL. Since WEBIDL's "return type" does not seem particularly relevant and since the terms "result type" and "return type" have similar connotations in this context, this appears to be an editorial oversight.

Update the command definitions to specify a "result type," and update the explanation of the commands' "remote end steps" to return an instance of the "result type."

See also the corresponding change to the WebDriver BiDi proposal: https://github.com/w3c/webdriver-bidi/pull/192


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/pull/37.html" title="Last updated on Nov 29, 2022, 1:10 AM UTC (ba85377)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/37/a9711aa...ba85377.html" title="Last updated on Nov 29, 2022, 1:10 AM UTC (ba85377)">Diff</a>