### PR TITLE
Normative: formalize "interaction.pressKeys" steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -754,7 +754,7 @@ The [=remote end steps=] given |session| and |command parameters| are:
 3. Let |keys| be the value of the <code>keys</code> field of |command
     parameters|.
 4. [=list/For each=] |key| of |keys|:
-    1. Run [=implementation-defined=] steps to simulate pressing |key|.
+    1. Run [=implementation-defined=] steps to simulate depressing |key|.
 5. [=list/For each=] |key| of |keys| in reverse [=List=] order:
     1. Run [=implementation-defined=] steps to simulate releasing |key|.
 6. Return a new map matching the `EmptyResult` production.

--- a/index.bs
+++ b/index.bs
@@ -15,6 +15,7 @@ Markup Shorthands: markdown yes
 
 <xmp class='link-defaults'>
 spec:infra; type:dfn; for:/; text:set
+spec:infra; type:dfn; text:list
 </xmp>
 
 <style>
@@ -27,6 +28,7 @@ table td, table th { border-left: solid; border-right: solid; border-bottom: sol
 
 <pre class='link-defaults'>
 spec:infra; type:dfn; for:/; text:set
+spec:infra; type:dfn; text:list
 </pre>
 
 <style>
@@ -739,11 +741,23 @@ Issue(34): This command does not yet have a means for indicating a screen-reader
 
 </dl>
 
+Note: Each string in `KeyCombination` represents a "raw key" consisting of a
+single code point with the same meaning as in <a
+href="https://w3c.github.io/webdriver/#keyboard-actions">WebDriver's keyboard
+actions</a>. For example, `["\uE008", "a"]` means holding the left shift key
+and pressing "a", and then releasing the left shift key. [[WEBDRIVER]]
+
 The [=remote end steps=] given |session| and |command parameters| are:
 
 1. [=Try=] to run an [=implementation-defined=] security check, e.g. honor OS settings for whether it allows keyboard simulation.
 2. [=Try=] to [=check that one of the expected applications has focus=].
-3. Run <a>implementation-defined</a> steps to simulate pressing the key combination represented in `KeyCombination`, such that they first item in the array is pressed first, and then each other key is pressed, in order, and finally the keys are released in reverse order. Each string in `KeyCombination` represents a "raw key" consisting of a single code point with the same meaning as in <a href="https://w3c.github.io/webdriver/#keyboard-actions">WebDriver's keyboard actions</a>. For example, `["\uE008", "a"]` means holding the left shift key and pressing "a", and then releasing the left shift key. [[WEBDRIVER]]
+3. Let |keys| be the value of the <code>keys</code> field of |command
+    parameters|.
+4. [=list/For each=] |key| of |keys|:
+    1. Run [=implementation-defined=] steps to simulate pressing |key|.
+5. [=list/For each=] |key| of |keys| in reverse [=List=] order:
+    1. Run [=implementation-defined=] steps to simulate releasing |key|.
+6. Return a new map matching the `EmptyResult` production.
 
 ### Events ### {#module-interaction-events}
 

--- a/index.bs
+++ b/index.bs
@@ -323,6 +323,10 @@ The following table lists each <dfn>error code</dfn>, its associated JSON `error
     <td>`session not created`
     <td>A new [=session=] could not be created.
   <tr>
+    <td><dfn for="error code">cannot simulate keyboard interaction</dfn>
+    <td>`cannot simulate keyboard interaction`
+    <td>The [=remote end=] cannot simulate keyboard interaction.
+  <tr>
     <td><dfn for="error code">invalid OS focus state</dfn>
     <td>`invalid OS focus state`
     <td>The application that currently has OS focus is not one of the expected applications.
@@ -332,6 +336,11 @@ Security checks {#security-checks}
 ----------------------------------
 
 In order to mitigate security risks when using this API, there are some security checks for certain commands.
+
+To <dfn>check that keyboard interaction can be simulated</dfn>:
+
+1. If the remote end cannot simulate keyboard interaction for any [=implementation-defined=] reason, then return an [=error=] with [=error code=] [=cannot simulate keyboard interaction=].
+2. Return [=success=] with data null.
 
 To <dfn>check that one of the expected applications has focus</dfn>:
 
@@ -749,7 +758,7 @@ and pressing "a", and then releasing the left shift key. [[WEBDRIVER]]
 
 The [=remote end steps=] given |session| and |command parameters| are:
 
-1. [=Try=] to run an [=implementation-defined=] security check, e.g. honor OS settings for whether it allows keyboard simulation.
+1. [=Try=] to [=check that keyboard interaction can be simulated=].
 2. [=Try=] to [=check that one of the expected applications has focus=].
 3. Let |keys| be the value of the <code>keys</code> field of |command
     parameters|.


### PR DESCRIPTION
- Reference the input parameters by name rather than by type.
- Delineate implementation-defined behavior in dedicated steps.
- Specify a return value for successful operations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/pull/41.html" title="Last updated on Nov 29, 2022, 7:41 PM UTC (3215292)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/41/6e490f2...3215292.html" title="Last updated on Nov 29, 2022, 7:41 PM UTC (3215292)">Diff</a>