### PR TITLE
Editorial: define variable in event algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -767,7 +767,8 @@ When the assistive technology would send some text |data| (a string, without spe
 1. Optionally, return. This step allows for an [=implementation-defined=] security check, to sandbox what information to expose.
 2. Let |params| be a [=map=] matching the `InteractionCapturedOutputParameters` production with the `data` field set to |data|.
 3. Let |body| be a [=map=] matching the `InteractionCapturedOutputEvent` production with the `params` field set to |params|.
-4. [=Emit an event=] with |session| and |body|.
+4. [=list/For each=] |session| of [=active sessions=]:
+    1. [=Emit an event=] with |session| and |body|.
 
 
 Privacy {#privacy}


### PR DESCRIPTION
Prior to this patch, the variable "session" was referenced without being declared. Although the WebDriver BiDi specification includes a rich concept of event subscriptions [1], this proposal uses a much less expressive model. Notably, a remote end only has a single active session at any given moment.

Define the "session" variable to take the value of the one and only active session.

[1] https://w3c.github.io/webdriver-bidi/#command-session-subscribe


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/pull/47.html" title="Last updated on Nov 29, 2022, 9:17 PM UTC (54c3ef1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/47/6e490f2...54c3ef1.html" title="Last updated on Nov 29, 2022, 9:17 PM UTC (54c3ef1)">Diff</a>