### PR TITLE
Editorial: Correct "process capabilities" algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -216,9 +216,7 @@ To <dfn>process capabilities</dfn> with argument |parameters|, the [=remote end=
     1. Let |required capabilities| be |parameters|["`capabilities`"]["`alwaysMatch`"].
 2. Otherwise:
     1. Let |required capabilities| be a new [=map=].
-3. Let |matched capabilities| be the result of [=trying=] to [=match capabilities=] given |required capabilities|.
-4. If |matched capabilities| is not null, then return [=success=] with data |matched capabilities|.
-5. Return [=success=] with data null.
+3. Return the result of [=match capabilities=] given |required capabilities|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -212,8 +212,10 @@ The following table of <dfn>standard capabilities</dfn> enumerates the capabilit
 
 To <dfn>process capabilities</dfn> with argument |parameters|, the [=remote end=] must:
 
-1. Let |capabilities request| be |parameters|["`capabilities`"] if it <a for=map>exists</a>, else null.
-2. Let |required capabilities| be |capabilities request|["`alwaysMatch`"] if it <a for=map>exists</a>, else null.
+1. If |parameters|["`capabilities`"] [=map/exists=] and |parameters|["`capabilities`"]["`alwaysMatch`"] [=map/exists=]:
+    1. Let |required capabilities| be |parameters|["`capabilities`"]["`alwaysMatch`"].
+2. Otherwise:
+    1. Let |required capabilities| be a new [=map=].
 3. Let |matched capabilities| be the result of [=trying=] to [=match capabilities=] given |required capabilities|.
 4. If |matched capabilities| is not null, then return [=success=] with data |matched capabilities|.
 5. Return [=success=] with data null.


### PR DESCRIPTION
Correct the derivation of "required capabilities" and simplify the return value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/pull/55.html" title="Last updated on Dec 13, 2022, 3:00 AM UTC (6b31f7e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/55/26e83e2...6b31f7e.html" title="Last updated on Dec 13, 2022, 3:00 AM UTC (6b31f7e)">Diff</a>