### PR TITLE
Editorial: rename "respond with an error"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -398,20 +398,20 @@ Note: a future iteration of this specification may allow multiple connections, t
 
 To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=] |connection|, type |type| and data |data|:
 
-1. If |type| is not [text](https://tools.ietf.org/html/rfc6455#section-5.2), [=respond with an error=] given |connection|, null, and [=invalid argument=], and finally return.
+1. If |type| is not [text](https://tools.ietf.org/html/rfc6455#section-5.2), [=send an error response=] given |connection|, null, and [=invalid argument=], and finally return.
 2. [=Assert=]: |data| is a [=scalar value string=], because the [WebSocket handling errors in UTF-8-encoded data=](https://tools.ietf.org/html/rfc6455#section-8.1) would already have [failed the WebSocket connection](https://tools.ietf.org/html/rfc6455#section-7.1.7) otherwise.
 3. If there is a [=session=] [=associated with connection=] |connection|, let |session| be that session. Otherwise if |connection| is in the set of [=WebSocket connections not associated with a session=], let |session| be null. Otherwise, return.
-4. Let |parsed| be the result of [=parsing JSON into Infra values=] given |data|. If this throws an exception, then [=respond with an error=] given |connection|, null, and [=invalid argument=], and finally return.
+4. Let |parsed| be the result of [=parsing JSON into Infra values=] given |data|. If this throws an exception, then [=send an error response=] given |connection|, null, and [=invalid argument=], and finally return.
 5. Match parsed against the [=remote end definition=]. If this results in a match:
     1. Let |matched| be the map representing the matched data.
     2. [=Assert=]: |matched| <a for=map>contains</a> "`id`", "`method`", and "`params`".
     3. Let |command id| be |matched|["`id`"].
     4. Let |method| be |matched|["`method`"].
     5. Let |command| be the command with [=command name=] |method|.
-    6. If |session| is null and |command| is not a [=static command=], then [=respond with an error=] given |connection|, |command id|, and [=invalid session id=], and return.
+    6. If |session| is null and |command| is not a [=static command=], then [=send an error response=] given |connection|, |command id|, and [=invalid session id=], and return.
     7. Run the following steps [=in parallel=]:
         1. Let |result| be the result of running the [=remote end steps=] for |command| given |session| and [=command parameters=] |matched|["`params`"].
-        2. If |result| is an [=error=], then [=respond with an error=] given |connection|, |command id|, and |result|'s [=error code=], and finally return.
+        2. If |result| is an [=error=], then [=send an error response=] given |connection|, |command id|, and |result|'s [=error code=], and finally return.
         3. Let |value| be |result|'s data.
         4. [=Assert=]: |value| matches the definition for the [=result type=] corresponding to the command with [=command name=] |method|.
         5. If |method| is "`session.new`", let [=session=] be the entry in the list of [=active sessions=] whose [=session ID=] is equal to the "`sessionId`" property of |value|, let |session|'s [=WebSocket connection=] be |connection|, and remove |connection| from the set of [=WebSocket connections not associated with a session=].
@@ -423,7 +423,7 @@ To <dfn>handle an incoming message</dfn> given a [=WebSocket connection=] |conne
     2. If |parsed| is a [=map=] and |parsed|["`id`"] <a for=map>exists</a> and is an integer greater than or equal to zero, set |command id| to that integer.
     3. Let |error code| be [=invalid argument=].
     4. If |parsed| is a [=map=] and |parsed|["`method`"] <a for=map>exists</a> and is a string, but |parsed|["`method`"] is not in the [=set of all command names=], set |error code| to [=unknown command=].
-    5. [=Respond with an error=] given |connection|, |command id|, and |error code|.
+    5. [=Send an error response=] given |connection|, |command id|, and |error code|.
 
 </div>
 
@@ -441,7 +441,7 @@ To <dfn>emit an event</dfn> given |session|, and |body|:
 
 <div algorithm>
 
-To <dfn>respond with an error</dfn> given a [=WebSocket connection=] |connection|, |command id|, and |error code|:
+To <dfn>send an error response</dfn> given a [=WebSocket connection=] |connection|, |command id|, and |error code|:
 
   1. Let |error data| be a new [=map=] matching the `ErrorResponse` production in the [=local end definition=], with the `id` field set to |command id|, the `error` field set to |error code|, the `message` field set to an [=implementation-defined=] string containing a human-readable definition of the error that occurred and the `stacktrace` field optionally set to an [=implementation-defined=] string containing a stack trace report of the active stack frames at the time when the error occurred.
   2. Let |response| be the result of [=serialize an infra value to JSON bytes=] given |error data|.


### PR DESCRIPTION
The proposal defines "error" as an internal type for describing one kind of result of fallible algorithms, and it defines "ErrorResponse" as a type of message which may be sent to clients. The algorithm used to transmit error responses to clients is named "respond with an error" even though it does not use the "error" type.

Rename "respond with an error" to "send an error response" to more accurately describe the types involved.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/pull/56.html" title="Last updated on Jan 24, 2023, 12:33 AM UTC (c336024)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/56/3ad852c...c336024.html" title="Last updated on Jan 24, 2023, 12:33 AM UTC (c336024)">Diff</a>