### PR TITLE
Editorial: add references to definitions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -54,7 +54,7 @@ A connection can have 0 or more [=sessions=]. Each session corresponds to an ins
 
 When a remote end supports multiple sessions, it does not necessarily mean that there will be multiple ATs running at the same time in the same instance of an OS. Some ATs might not be able to function properly if there are other ATs running at the same time. The AT Driver [=session=] concept can still be used by having the remote end run in a separate environment and each AT is run in its own OS instance (for example in a virtual machine), and the remote end proxies messages in some fashion.
 
-Commands are grouped into modules. The modules could be: Sessions, Settings, Actions.
+Commands are grouped into [=modules=]. The modules could be: Sessions, Settings, Actions.
 
 Message transport is provided using the WebSocket protocol.
 
@@ -515,7 +515,7 @@ The `CapabilitiesRequest` type represents capabilities requested for a session.
 The <dfn>session.new</dfn> command allows creating a new [=session=]. This is a [=static command=].
 
 <dl>
-  <dt>Command Type
+  <dt>[=Command Type=]
   <dd>
 
   <xmp class="cddl remote-cddl">
@@ -622,7 +622,7 @@ The `VendorSettingsGetSettingsResult` type contains a list of settings and their
 This command sets the values of one or more settings.
 
 <dl>
-  <dt>Command Type</dt>
+  <dt>[=Command Type=]</dt>
   <dd>
     <xmp class="cddl remote-cddl">
     VendorSettingsSetSettingsCommand = {
@@ -656,7 +656,7 @@ The <a>remote end steps</a> given |session| and |command parameters| are <a>impl
 This command returns a list of the requested settings and their values.
 
 <dl>
-  <dt>Command Type</dt>
+  <dt>[=Command Type=]</dt>
   <dd>
     <xmp class="cddl remote-cddl">
     VendorSettingsGetSettingsCommand = {
@@ -689,7 +689,7 @@ The <a>remote end steps</a> given |session| and |command parameters| are <a>impl
 This command returns a list of all settings that the [=remote end=] supports, and their values.
 
 <dl>
-  <dt>Command Type</dt>
+  <dt>[=Command Type=]</dt>
   <dd>
     <xmp class="cddl remote-cddl">
     VendorSettingsGetSupportedSettingsCommand = {
@@ -749,7 +749,7 @@ The <dfn>interaction.pressKeys</dfn> command simulates pressing a key combinatio
 Issue(34): This command does not yet have a means for indicating a screen-reader specific modifier key (or keys).
 
 <dl>
-  <dt>Command Type
+  <dt>[=Command Type=]
   <dd>
 
   <pre class="cddl remote-cddl">


### PR DESCRIPTION
Add references to the definitions of the terms "module" and "command type." This justifies the definitions, supports new readers, and suppresses two instances of the following warning from the Bikeshed build tool:

>     WARNING: Unexported dfn that's not referenced locally - did you mean to export it?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/pull/57.html" title="Last updated on Dec 13, 2022, 6:09 PM UTC (5695d2b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/57/26e83e2...5695d2b.html" title="Last updated on Dec 13, 2022, 6:09 PM UTC (5695d2b)">Diff</a>