### PR TITLE
Normative: destroy sessions with zero connections

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -457,9 +457,9 @@ To <dfn>handle a connection closing</dfn> given a [=WebSocket connection=] |conn
   1. If there is a [=session=] [=associated with connection=] |connection|:
       1. Let |session| be the [=session=] [=associated with connection=] |connection|.
       2. Remove |connection| from |session|'s [=session WebSocket connections=].
+      3. If |session|'s [=session WebSocket connections=] is [=list/empty=]:
+          1. Remove |session| from [=active sessions=].
   2. Otherwise, if the set of [=WebSocket connections not associated with a session=] contains |connection|, remove |connection| from that set.
-
-Issue: As in WebDriver BiDi, this does not end any session. Not sure if we want to allow reconnecting to the same session, or implicitly end the session.
 
 </div>
 


### PR DESCRIPTION
The algorithm for the "session.new" command includes a guard for the case where an active session already exists:

> 2. If the list of [=active sessions=] is not empty, then return [=error=] with error code [=session not created=].

Prior to this commit, sessions were not removed from this list when they were depleted of connections. Following the creation and termination of some initial connection, a remote end would forever deny further requests to create new sessions.

Destroy the active session when its final connection is closed so that a new session may be subsequently created.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/pull/60.html" title="Last updated on Dec 14, 2022, 3:06 AM UTC (03b03a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/60/26e83e2...03b03a5.html" title="Last updated on Dec 14, 2022, 3:06 AM UTC (03b03a5)">Diff</a>