### PR TITLE
Editorial: refactor setting name validation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -590,13 +590,13 @@ A [=remote end=] has an associated set of <dfn for="remote end">supported settin
 
 <div algorithm>
 
-To determine if a <dfn>setting name is invalid</dfn> given string |name|:
+To <dfn>validate setting name</dfn> given string |name|:
 
 1. If [=supported settings=] is null:
-    1. Return false.
+    1. Return `"unknown"`.
 2. If [=supported settings=] [=list/contains=] |name|:
-    1. Return false.
-3. Return true.
+    1. Return `"valid"`.
+3. Return `"invalid"`.
 
 </div>
 
@@ -606,7 +606,7 @@ To <dfn>get settings</dfn> given a [=list=] of strings |names|:
 
 1. Let |items| be a new [=list=].
 2. [=list/For each=] |name| of |names|:
-    1. If [=setting name is invalid=] given |name|:
+    1. If [=validate setting name=] given |name| is `"invalid"`:
         1. Return an [=error=] with [=error code=] [=invalid argument=].
     2. Let |value| be the value of the setting named |name|.
     3. Let |item| be a new [=map=] matching the `VendorSettingsGetSettingsResultItem` production in the [=local end definition=] with the `name` field set to |name| and the `value` field set to |value|.
@@ -620,7 +620,7 @@ To <dfn>get settings</dfn> given a [=list=] of strings |names|:
 
 To <dfn>modify setting</dfn> given string |name| and |value|:
 
-1. If [=setting name is invalid=] given |name|:
+1. If [=validate setting name=] given |name| is `"invalid"`:
     1. Return an [=error=] with [=error code=] [=invalid argument=].
 2. Take any [=implementation-defined=] steps to change the [=remote end=] setting named |name| to the value |value|.
 3. If there is any [=implementation-defined=] indication that the setting named |name| does not hold the value |value|:


### PR DESCRIPTION
In describing the absence of validity, the algorithm named "setting name is invalid" was difficult to reason about. Although an algorithm designed to report on positive validity (e.g. one named "setting name is valid") would be both more traditional and easier to understand, it would also suggest inaccurate state in certain implementations. Specifically, in implementations which cannot reject unrecognized setting names, an algorithm titled "setting name is valid" would claim that any arbitrary setting name is "valid."

Refactor the algorithm to return one of three values to accurately describe the result and avoid misleading call sites.

---

@jkva This is the best I could come up with following [our discussion in gh-54](https://github.com/w3c/aria-at-automation/pull/54#discussion_r1052669178). I'm not convinced it's an improvement, though, particularly after learning that, unlike [ECMAScript's enums](https://tc39.es/ecma262/#sec-enum-specification-type), [enum values in WebIDL are indistinguishable from strings](https://webidl.spec.whatwg.org/#idl-enums).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/pull/63.html" title="Last updated on Mar 28, 2023, 10:45 PM UTC (8c2c5b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/63/acbf00d...8c2c5b3.html" title="Last updated on Mar 28, 2023, 10:45 PM UTC (8c2c5b3)">Diff</a>