### PR TITLE
Normative: remove prefix from settings module

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -133,7 +133,7 @@ Command = {
 
 CommandData = (
   SessionCommand //
-  VendorSettingsCommand //
+  SettingsCommand //
   InteractionCommand
 )
 
@@ -170,7 +170,7 @@ ErrorResponse = {
 ResultData = (
   EmptyResult //
   SessionResult //
-  VendorSettingsResult
+  SettingsResult
 )
 
 EmptyResult = {}
@@ -586,14 +586,10 @@ The [=remote end steps=] given |session| and |command parameters| are:
 
 </div>
 
-The &lt;vendor>:settings Module {#module-vendor-settings}
+The settings Module {#module-settings}
 --------------------------------------
 
-Currently, there are no standardized settings. Implementations that wish to allow controlling and reading settings through the protocol defined in this specification must support settings as an <a>extension module</a>, with the structure defined in this section. Implementations are strongly encouraged to review the security implications of each setting, and only support the settings that are deemed safe. It is not defined what constitutes a setting, however, it is intended to represent user preferences such as the default voice, or the default rate of speech.
-
-In the schema definitions in this section, `<vendor>` is a placeholder for an <a>implementation-defined</a> prefix for the <a>extension module</a>. The value of the prefix should be the name of the vendor or the assistive technology product, as appropriate.
-
-Note: The prefix could be, for example, `nvda`, `jaws`, or `macOSVoiceOver`.
+Currently, there are no standardized settings. Implementations are strongly encouraged to review the security implications of each setting they offer to end users, and only expose the settings that they deem safe. This specification does not define what constitutes a setting, but the settings module is designed to control user preferences such as the default voice, or the default rate of speech.
 
 A [=remote end=] has an associated set of <dfn for="remote end">supported settings</dfn>, which is either null or a [=set=] of strings which contains the name of every setting that may be referenced by this [=module=].
 
@@ -618,9 +614,9 @@ To <dfn>get settings</dfn> given a [=list=] of strings |names|:
     1. If [=setting name is invalid=] given |name|:
         1. Return an [=error=] with [=error code=] <a for="error code">invalid argument</a>.
     2. Let |value| be the value of the setting named |name|.
-    3. Let |item| be a new [=map=] matching the `VendorSettingsGetSettingsResultItem` production in the [=local end definition=] with the `name` field set to |name| and the `value` field set to |value|.
+    3. Let |item| be a new [=map=] matching the `SettingsGetSettingsResultItem` production in the [=local end definition=] with the `name` field set to |name| and the `value` field set to |value|.
     4. [=list/Append=] |item| to |items|.
-3. Let |body| be a new [=map=] matching the `VendorSettingsGetSettingsResult` production, with the `settings` field set to |items|.
+3. Let |body| be a new [=map=] matching the `SettingsGetSettingsResult` production, with the `settings` field set to |items|.
 4. Return [=success=] with data |body|.
 
 </div>
@@ -642,53 +638,53 @@ Note: Today's implementations may not be able to detect invalid setting names or
 
 Issue: Require implementations to maintain a static list of supported settings.
 
-### Definition ### {#module-vendor-settings-definition}
+### Definition ### {#module-settings-definition}
 
 <a>Remote end definition</a>
 
 <xmp class="cddl remote-cddl">
-VendorSettingsCommand = {
-  VendorSettingsSetSettingsCommand //
-  VendorSettingsGetSettingsCommand //
-  VendorSettingsGetSupportedSettingsCommand
+SettingsCommand = {
+  SettingsSetSettingsCommand //
+  SettingsGetSettingsCommand //
+  SettingsGetSupportedSettingsCommand
 }
 </xmp>
 
 <a>Local end definition</a>
 
 <xmp class="cddl local-cddl">
-VendorSettingsResult = {
-  VendorSettingsGetSettingsResult
+SettingsResult = {
+  SettingsGetSettingsResult
 }
 </xmp>
 
-### Types ### {#module-vendor-settings-types}
+### Types ### {#module-settings-types}
 
-#### The VendorSettingsGetSettingsResult type #### {#module-vendor-settings-get-settings-result}
+#### The SettingsGetSettingsResult type #### {#module-settings-get-settings-result}
 
 [=Local end definition=]:
 
 <xmp class="cddl local-cddl">
-VendorSettingsGetSettingsResult = {
-  settings: [1* VendorSettingsGetSettingsResultItem ],
+SettingsGetSettingsResult = {
+  settings: [1* SettingsGetSettingsResultItem ],
 }
 
-VendorSettingsGetSettingsResultItem = {
+SettingsGetSettingsResultItem = {
   name: text,
   value: any,
   Extensible,
 }
 </xmp>
 
-The `VendorSettingsGetSettingsResult` type contains a list of settings and their values.
+The `SettingsGetSettingsResult` type contains a list of settings and their values.
 
 ### Commands ### {#module-settings-commands}
 
-#### The &lt;vendor>:settings.setSettings Command #### {#command-vendor-settings-set-settings}
+#### The settings.setSettings Command #### {#command-settings-set-settings}
 
-The <dfn>&lt;vendor>:settings.setSettings</dfn> command sets the values of one or more settings.
+The <dfn>settings.setSettings</dfn> command sets the values of one or more settings.
 
-Note: Today's implementations may not be able to detect failed modification operations. [=&lt;vendor>:settings.setSettings=] is designed to reflect that reality. Clients should therefore interpret [=successes=] with some skepticism as such results do not necessarily indicate that the referenced setting has the desired value.
+Note: Today's implementations may not be able to detect failed modification operations. [=settings.setSettings=] is designed to reflect that reality. Clients should therefore interpret [=successes=] with some skepticism as such results do not necessarily indicate that the referenced setting has the desired value.
 
 Issue: Require implementations to report failures in settings modification operations.
 
@@ -696,16 +692,16 @@ Issue: Require implementations to report failures in settings modification opera
   <dt>[=Command Type=]</dt>
   <dd>
     <xmp class="cddl remote-cddl">
-    VendorSettingsSetSettingsCommand = {
-      method: "<vendor>:settings.setSettings",
-      params: VendorSettingsSetSettingsParameters
+    SettingsSetSettingsCommand = {
+      method: "settings.setSettings",
+      params: SettingsSetSettingsParameters
     }
 
-    VendorSettingsSetSettingsParameters = {
-      settings: [1* VendorSettingsSetSettingsParametersItem ],
+    SettingsSetSettingsParameters = {
+      settings: [1* SettingsSetSettingsParametersItem ],
     }
 
-    VendorSettingsSetSettingsParametersItem = {
+    SettingsSetSettingsParametersItem = {
       name: text,
       value: any,
       Extensible,
@@ -720,7 +716,7 @@ Issue: Require implementations to report failures in settings modification opera
   </dd>
 </dl>
 
-<div algorithm="remote end steps for &lt;vendor>:settings.setSettings">
+<div algorithm="remote end steps for settings.setSettings">
 
 The [=remote end steps=] given <var ignore>session</var> and |command parameters| are:
 
@@ -734,24 +730,24 @@ The [=remote end steps=] given <var ignore>session</var> and |command parameters
 
 </div>
 
-#### The &lt;vendor>:settings.getSettings Command #### {#command-vendor-settings-get-settings}
+#### The settings.getSettings Command #### {#command-settings-get-settings}
 
-The <dfn>&lt;vendor>:settings.getSettings command</dfn> returns a list of the requested settings and their values.
+The <dfn>settings.getSettings command</dfn> returns a list of the requested settings and their values.
 
 <dl>
   <dt>[=Command Type=]</dt>
   <dd>
     <xmp class="cddl remote-cddl">
-    VendorSettingsGetSettingsCommand = {
-      method: "<vendor>:settings.getSettings",
-      params: VendorSettingsGetSettingsParameters
+    SettingsGetSettingsCommand = {
+      method: "settings.getSettings",
+      params: SettingsGetSettingsParameters
     }
 
-    VendorSettingsGetSettingsParameters = {
-      settings: [1* VendorSettingsGetSettingsParametersItem ],
+    SettingsGetSettingsParameters = {
+      settings: [1* SettingsGetSettingsParametersItem ],
     }
 
-    VendorSettingsGetSettingsParametersItem = {
+    SettingsGetSettingsParametersItem = {
       name: text,
       Extensible,
     }
@@ -760,12 +756,12 @@ The <dfn>&lt;vendor>:settings.getSettings command</dfn> returns a list of the re
   <dt>[=Result Type=]</dt>
   <dd>
     <xmp class="cddl">
-    VendorSettingsGetSettingsResult
+    SettingsGetSettingsResult
     </xmp>
   </dd>
 </dl>
 
-<div algorithm="remote end steps for &lt;vendor>:settings.getSettings">
+<div algorithm="remote end steps for settings.getSettings">
 
 The <a>remote end steps</a> given <var ignore>session</var> and |command parameters| are:
 
@@ -774,16 +770,16 @@ The <a>remote end steps</a> given <var ignore>session</var> and |command paramet
 
 </div>
 
-#### The &lt;vendor>:settings.getSupportedSettings Command #### {#command-vendor-settings-get-supported-settings}
+#### The settings.getSupportedSettings Command #### {#command-settings-get-supported-settings}
 
-The <dfn>&lt;vendor>:settings.getSupportedSettings command</dfn> returns a list of all settings that the [=remote end=] supports, and their values.
+The <dfn>settings.getSupportedSettings command</dfn> returns a list of all settings that the [=remote end=] supports, and their values.
 
 <dl>
   <dt>[=Command Type=]</dt>
   <dd>
     <xmp class="cddl remote-cddl">
-    VendorSettingsGetSupportedSettingsCommand = {
-      method: "<vendor>:settings.getSupportedSettings",
+    SettingsGetSupportedSettingsCommand = {
+      method: "settings.getSupportedSettings",
       params: EmptyParams
     }
     </xmp>
@@ -791,13 +787,13 @@ The <dfn>&lt;vendor>:settings.getSupportedSettings command</dfn> returns a list 
   <dt>[=Result Type=]</dt>
   <dd>
     <xmp class="cddl">
-    VendorSettingsGetSettingsResult
+    SettingsGetSettingsResult
     </xmp>
   </dd>
 </dl>
 
 
-<div algorithm="remote end steps for &lt;vendor>:settings.getSupportedSettings">
+<div algorithm="remote end steps for settings.getSupportedSettings">
 
 The <a>remote end steps</a> given <var ignore>session</var> and <var ignore>command parameters</var> are:
 
@@ -811,7 +807,7 @@ The <a>remote end steps</a> given <var ignore>session</var> and <var ignore>comm
 
 </div>
 
-### Events ### {#module-vendor-settings-events}
+### Events ### {#module-settings-events}
 
 Issue: Do we need a "setting changed" event?
 

--- a/schemas/at-driver-local.cddl
+++ b/schemas/at-driver-local.cddl
@@ -25,7 +25,7 @@ ErrorResponse = {
 ResultData = (
   EmptyResult //
   SessionResult //
-  VendorSettingsResult
+  SettingsResult
 )
 
 EmptyResult = {}
@@ -58,15 +58,15 @@ SessionNewResult = {
   }
 }
 
-VendorSettingsResult = {
-  VendorSettingsGetSettingsResult
+SettingsResult = {
+  SettingsGetSettingsResult
 }
 
-VendorSettingsGetSettingsResult = {
-  settings: [1* VendorSettingsGetSettingsResultItem ],
+SettingsGetSettingsResult = {
+  settings: [1* SettingsGetSettingsResultItem ],
 }
 
-VendorSettingsGetSettingsResultItem = {
+SettingsGetSettingsResultItem = {
   name: text,
   value: any,
   Extensible,

--- a/schemas/at-driver-local.json
+++ b/schemas/at-driver-local.json
@@ -31,7 +31,7 @@
       "oneOf": [
         { "$ref": "#/$defs/EmptyResult" },
         { "$ref": "#/$defs/SessionResult" },
-        { "$ref": "#/$defs/VendorSettingsResult" }
+        { "$ref": "#/$defs/SettingsResult" }
       ]
     },
     "EmptyResult": {
@@ -80,24 +80,24 @@
       "required": ["sessionId", "capabilities"],
       "additionalProperties": false
     },
-    "VendorSettingsResult": {
+    "SettingsResult": {
       "oneOf": [
-        { "$ref": "#/$defs/VendorSettingsGetSettingsResult" }
+        { "$ref": "#/$defs/SettingsGetSettingsResult" }
       ]
     },
-    "VendorSettingsGetSettingsResult": {
+    "SettingsGetSettingsResult": {
       "type": "object",
       "properties": {
         "settings": {
           "type": "array",
           "minItems": 1,
-          "items": { "$ref": "#/$defs/VendorSettingsGetSettingsResultItem" }
+          "items": { "$ref": "#/$defs/SettingsGetSettingsResultItem" }
         }
       },
       "required": ["settings"],
       "additionalProperties": false
     },
-    "VendorSettingsGetSettingsResultItem": {
+    "SettingsGetSettingsResultItem": {
       "type": "object",
       "properties": {
         "name": { "type": "string" },

--- a/schemas/at-driver-remote.cddl
+++ b/schemas/at-driver-remote.cddl
@@ -10,7 +10,7 @@ Command = {
 
 CommandData = (
   SessionCommand //
-  VendorSettingsCommand //
+  SettingsCommand //
   InteractionCommand
 )
 
@@ -34,43 +34,43 @@ CapabilitiesRequestParameters = {
   ?alwaysMatch: CapabilitiesRequest,
 }
 
-VendorSettingsCommand = {
-  VendorSettingsSetSettingsCommand //
-  VendorSettingsGetSettingsCommand //
-  VendorSettingsGetSupportedSettingsCommand
+SettingsCommand = {
+  SettingsSetSettingsCommand //
+  SettingsGetSettingsCommand //
+  SettingsGetSupportedSettingsCommand
 }
 
-VendorSettingsSetSettingsCommand = {
-  method: "<vendor>:settings.setSettings",
-  params: VendorSettingsSetSettingsParameters
+SettingsSetSettingsCommand = {
+  method: "settings.setSettings",
+  params: SettingsSetSettingsParameters
 }
 
-VendorSettingsSetSettingsParameters = {
-  settings: [1* VendorSettingsSetSettingsParametersItem ],
+SettingsSetSettingsParameters = {
+  settings: [1* SettingsSetSettingsParametersItem ],
 }
 
-VendorSettingsSetSettingsParametersItem = {
+SettingsSetSettingsParametersItem = {
   name: text,
   value: any,
   Extensible,
 }
 
-VendorSettingsGetSettingsCommand = {
-  method: "<vendor>:settings.getSettings",
-  params: VendorSettingsGetSettingsParameters
+SettingsGetSettingsCommand = {
+  method: "settings.getSettings",
+  params: SettingsGetSettingsParameters
 }
 
-VendorSettingsGetSettingsParameters = {
-  settings: [1* VendorSettingsGetSettingsParametersItem ],
+SettingsGetSettingsParameters = {
+  settings: [1* SettingsGetSettingsParametersItem ],
 }
 
-VendorSettingsGetSettingsParametersItem = {
+SettingsGetSettingsParametersItem = {
   name: text,
   Extensible,
 }
 
-VendorSettingsGetSupportedSettingsCommand = {
-  method: "<vendor>:settings.getSupportedSettings",
+SettingsGetSupportedSettingsCommand = {
+  method: "settings.getSupportedSettings",
   params: EmptyParams
 }
 

--- a/schemas/at-driver-remote.json
+++ b/schemas/at-driver-remote.json
@@ -17,7 +17,7 @@
     "CommandData": {
       "oneOf": [
         { "$ref": "#/$defs/SessionCommand" },
-        { "$ref": "#/$defs/VendorSettingsCommand" },
+        { "$ref": "#/$defs/SettingsCommand" },
         { "$ref": "#/$defs/InteractionCommand" }
       ]
     },
@@ -58,35 +58,35 @@
       },
       "additionalProperties": false
     },
-    "VendorSettingsCommand": {
+    "SettingsCommand": {
       "oneOf": [
-        { "$ref": "#/$defs/VendorSettingsSetSettingsCommand" },
-        { "$ref": "#/$defs/VendorSettingsGetSettingsCommand" },
-        { "$ref": "#/$defs/VendorSettingsGetSupportedSettingsCommand" }
+        { "$ref": "#/$defs/SettingsSetSettingsCommand" },
+        { "$ref": "#/$defs/SettingsGetSettingsCommand" },
+        { "$ref": "#/$defs/SettingsGetSupportedSettingsCommand" }
       ]
     },
-    "VendorSettingsSetSettingsCommand": {
+    "SettingsSetSettingsCommand": {
       "type": "object",
       "properties": {
-        "method": { "enum": [ "<vendor>:settings.setSettings" ] },
-        "params": { "$ref": "#/$defs/VendorSettingsSetSettingsParameters" }
+        "method": { "enum": [ "settings.setSettings" ] },
+        "params": { "$ref": "#/$defs/SettingsSetSettingsParameters" }
       },
       "required": [ "method", "params" ],
       "additionalProperties": false
     },
-    "VendorSettingsSetSettingsParameters": {
+    "SettingsSetSettingsParameters": {
       "type": "object",
       "properties": {
         "settings": {
           "type": "array",
           "minItems": 1,
-          "items": { "$ref": "#/$defs/VendorSettingsSetSettingsParametersItem" }
+          "items": { "$ref": "#/$defs/SettingsSetSettingsParametersItem" }
         }
       },
       "required": [ "settings" ],
       "additionalProperties": false
     },
-    "VendorSettingsSetSettingsParametersItem": {
+    "SettingsSetSettingsParametersItem": {
       "type": "object",
       "properties": {
         "name": { "type": "string" },
@@ -94,38 +94,38 @@
       },
       "required": [ "name", "value" ]
     },
-    "VendorSettingsGetSettingsCommand": {
+    "SettingsGetSettingsCommand": {
       "type": "object",
       "properties": {
-        "method": { "enum": [ "<vendor>:settings.getSettings" ] },
-        "params": { "$ref": "#/$defs/VendorSettingsGetSettingsParameters" }
+        "method": { "enum": [ "settings.getSettings" ] },
+        "params": { "$ref": "#/$defs/SettingsGetSettingsParameters" }
       },
       "required": [ "method", "params" ],
       "additionalProperties": false
     },
-    "VendorSettingsGetSettingsParameters": {
+    "SettingsGetSettingsParameters": {
       "type": "object",
       "properties": {
         "settings": {
           "type": "array",
           "minItems": 1,
-          "items": { "$ref": "#/$defs/VendorSettingsGetSettingsParametersItem" }
+          "items": { "$ref": "#/$defs/SettingsGetSettingsParametersItem" }
         }
       },
       "required": [ "settings" ],
       "additionalProperties": false
     },
-    "VendorSettingsGetSettingsParametersItem": {
+    "SettingsGetSettingsParametersItem": {
       "type": "object",
       "properties": {
         "name": { "type": "string" }
       },
       "required": [ "name" ]
     },
-    "VendorSettingsGetSupportedSettingsCommand": {
+    "SettingsGetSupportedSettingsCommand": {
       "type": "object",
       "properties": {
-        "method": { "enum": [ "<vendor>:settings.getSupportedSettings" ] },
+        "method": { "enum": [ "settings.getSupportedSettings" ] },
         "params": { "$ref": "#/$defs/EmptyParams" }
       },
       "required": [ "method", "params" ],


### PR DESCRIPTION
Replace the templated "extension module" with a single concrete module for all vendors named settings. This improves the maintainability of the proposal and the usability of the protocol without meaningfully limiting implementation freedom or future protocol revisions.

Depends on gh-58. Resolves gh-48.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/pull/65.html" title="Last updated on Mar 29, 2023, 1:54 AM UTC (9f76a26)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/65/acbf00d...9f76a26.html" title="Last updated on Mar 29, 2023, 1:54 AM UTC (9f76a26)">Diff</a>