### PR TITLE
Editorial: define "Extensible" type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -121,10 +121,14 @@ This section gives the initial contents of the remote end definition and local e
 [=Remote end definition=]
 
 <xmp class="cddl remote-cddl">
+Extensible = {
+  *text => any
+}
+
 Command = {
   id: uint,
   CommandData,
-  *text => any,
+  Extensible,
 }
 
 CommandData = (
@@ -133,12 +137,16 @@ CommandData = (
   InteractionCommand
 )
 
-EmptyParams = { *text => any }
+EmptyParams = { Extensible }
 </xmp>
 
 [=Local end definition=]:
 
 <xmp class="cddl local-cddl">
+Extensible = {
+  *text => any
+}
+
 Message = (
   CommandResponse //
   ErrorResponse //
@@ -148,7 +156,7 @@ Message = (
 CommandResponse = {
   id: uint,
   result: ResultData,
-  *text => any
+  Extensible,
 }
 
 ErrorResponse = {
@@ -156,7 +164,7 @@ ErrorResponse = {
   error: "unknown error" / "unknown command" / "invalid argument" / "session not created",
   message: text,
   ?stacktrace: text,
-  *text => any
+  Extensible,
 }
 
 ResultData = (
@@ -169,7 +177,7 @@ EmptyResult = {}
 
 Event = {
   EventData,
-  *text => any
+  Extensible,
 }
 
 EventData = (
@@ -513,7 +521,7 @@ CapabilitiesRequest = {
   ?atName: text,
   ?atVersion: text,
   ?platformName: text,
-  *text => any
+  Extensible,
 }
 </xmp>
 
@@ -552,7 +560,7 @@ The <dfn>session.new</dfn> command allows creating a new [=session=]. This is a 
       atName: text,
       atVersion: text,
       platformName: text,
-      *text => any
+      Extensible,
     }
   }
   </xmp>
@@ -667,7 +675,7 @@ VendorSettingsGetSettingsResult = {
 VendorSettingsGetSettingsResultItem = {
   name: text,
   value: any,
-  *text => any
+  Extensible,
 }
 </xmp>
 
@@ -699,7 +707,7 @@ Issue: Require implementations to report failures in settings modification opera
     VendorSettingsSetSettingsParametersItem = {
       name: text,
       value: any,
-      *text => any
+      Extensible,
     }
     </xmp>
   </dd>
@@ -744,7 +752,7 @@ The <dfn>&lt;vendor>:settings.getSettings command</dfn> returns a list of the re
 
     VendorSettingsGetSettingsParametersItem = {
       name: text,
-      *text => any
+      Extensible,
     }
     </xmp>
   </dd>
@@ -830,7 +838,7 @@ InteractionEvent = (InteractionCapturedOutputEvent)
 <xmp class="cddl local-cddl">
 InteractionCapturedOutputParameters = {
   data: text,
-  *text => any
+  Extensible,
 }
 </xmp>
 
@@ -854,7 +862,7 @@ Issue(34): This command does not yet have a means for indicating a screen-reader
 
   InteractionPressKeysParameters = {
     "keys" => KeyCombination,
-    *text => any
+    Extensible,
   }
 
   KeyCombination = [

--- a/schemas/at-driver-local.cddl
+++ b/schemas/at-driver-local.cddl
@@ -1,3 +1,7 @@
+Extensible = {
+  *text => any
+}
+
 Message = (
   CommandResponse //
   ErrorResponse //
@@ -7,7 +11,7 @@ Message = (
 CommandResponse = {
   id: uint,
   result: ResultData,
-  *text => any
+  Extensible,
 }
 
 ErrorResponse = {
@@ -15,7 +19,7 @@ ErrorResponse = {
   error: "unknown error" / "unknown command" / "invalid argument" / "session not created",
   message: text,
   ?stacktrace: text,
-  *text => any
+  Extensible,
 }
 
 ResultData = (
@@ -28,7 +32,7 @@ EmptyResult = {}
 
 Event = {
   EventData,
-  *text => any
+  Extensible,
 }
 
 EventData = (
@@ -41,7 +45,7 @@ CapabilitiesRequest = {
   ?atName: text,
   ?atVersion: text,
   ?platformName: text,
-  *text => any
+  Extensible,
 }
 
 SessionNewResult = {
@@ -50,7 +54,7 @@ SessionNewResult = {
     atName: text,
     atVersion: text,
     platformName: text,
-    *text => any
+    Extensible,
   }
 }
 
@@ -65,14 +69,14 @@ VendorSettingsGetSettingsResult = {
 VendorSettingsGetSettingsResultItem = {
   name: text,
   value: any,
-  *text => any
+  Extensible,
 }
 
 InteractionEvent = (InteractionCapturedOutputEvent)
 
 InteractionCapturedOutputParameters = {
   data: text,
-  *text => any
+  Extensible,
 }
 
 InteractionCapturedOutputEvent = {

--- a/schemas/at-driver-remote.cddl
+++ b/schemas/at-driver-remote.cddl
@@ -1,7 +1,11 @@
+Extensible = {
+  *text => any
+}
+
 Command = {
   id: uint,
   CommandData,
-  *text => any,
+  Extensible,
 }
 
 CommandData = (
@@ -10,7 +14,7 @@ CommandData = (
   InteractionCommand
 )
 
-EmptyParams = { *text => any }
+EmptyParams = { Extensible }
 
 SessionCommand = (SessionNewCommand)
 
@@ -18,7 +22,7 @@ CapabilitiesRequest = {
   ?atName: text,
   ?atVersion: text,
   ?platformName: text,
-  *text => any
+  Extensible,
 }
 
 SessionNewCommand = {
@@ -48,7 +52,7 @@ VendorSettingsSetSettingsParameters = {
 VendorSettingsSetSettingsParametersItem = {
   name: text,
   value: any,
-  *text => any
+  Extensible,
 }
 
 VendorSettingsGetSettingsCommand = {
@@ -62,7 +66,7 @@ VendorSettingsGetSettingsParameters = {
 
 VendorSettingsGetSettingsParametersItem = {
   name: text,
-  *text => any
+  Extensible,
 }
 
 VendorSettingsGetSupportedSettingsCommand = {
@@ -79,7 +83,7 @@ InteractionPressKeysCommand = {
 
 InteractionPressKeysParameters = {
   "keys" => KeyCombination,
-  *text => any
+  Extensible,
 }
 
 KeyCombination = [


### PR DESCRIPTION
The name "Extensible" more clearly communicates the intent of the pattern which is used repeatedly in defining other types in the specification.

Resolves gh-28.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/pull/66.html" title="Last updated on Dec 22, 2022, 10:33 PM UTC (e090379)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/66/3ad852c...e090379.html" title="Last updated on Dec 22, 2022, 10:33 PM UTC (e090379)">Diff</a>