### PR TITLE
Editorial: correct command return value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -887,7 +887,8 @@ The [=remote end steps=] given |session| and |command parameters| are:
     1. Run [=implementation-defined=] steps to simulate depressing |key|.
 5. [=list/For each=] |key| of |keys| in reverse [=List=] order:
     1. Run [=implementation-defined=] steps to simulate releasing |key|.
-6. Return a new map matching the `EmptyResult` production.
+6. Let |body| be a new [=map=].
+7. Return [=success=] with data |body|.
 
 ### Events ### {#module-interaction-events}
 


### PR DESCRIPTION
The "handle an incoming message" algorithm expects every command to return either a "success" value or an "error" value:

>     1. Let |result| be the result of running the [=remote end steps=] for |command| given |session| and [=command parameters=] |matched|["`params`"].
>     2. If |result| is an [=error=], then [=respond with an error=] given |connection|, |command id|, and |result|'s [=error code=], and finally return.
>     3. Let |value| be |result|'s data.

Update the "interaction.pressKeys" algorithm to satisfy this expectation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/pull/67.html" title="Last updated on Jan 3, 2023, 11:19 PM UTC (8c18b91)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-at-automation/67/3ad852c...8c18b91.html" title="Last updated on Jan 3, 2023, 11:19 PM UTC (8c18b91)">Diff</a>