### PR TITLE
Update OS image used in continuous integration

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   main:
     name: Build, Validate and Deploy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: w3c/spec-prod@v2
@@ -16,7 +16,7 @@ jobs:
           BUILD_FAIL_ON: link-error
   check-cddl-consistency:
     name: Verify that the generated CDDL files are in sync with the inline CDDL
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -28,7 +28,7 @@ jobs:
         run: git diff --exit-code
   check-cddl-validity:
     name: Verify that the generated CDDL files are valid
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Get cddl version
@@ -53,7 +53,7 @@ jobs:
         run: ./scripts/test-cddl.sh
   check-json-schema-validity:
     name: Verify that the JSON schema files are valid
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Ubuntu 24.04 is the latest LTS release that is fully-supported by GitHub:

https://github.com/actions/runner-images/tree/cd9258380ce08e025f0087395112154dcec91049: